### PR TITLE
Use React.cloneElement() for child elements.

### DIFF
--- a/src/DateSelect.js
+++ b/src/DateSelect.js
@@ -51,8 +51,7 @@ var DateSelect = React.createClass({
 	},
 	renderChildren () {
 		return React.Children.map(this.props.children, (child) => {
-			child.props.onClick = this.openDateSelect;
-			return child;
+			return React.cloneElement(child, { onClick: this.openDateSelect });
 		});
 	},
 	renderButton () {


### PR DESCRIPTION
Removes 

```
Warning: Don't set .props.onClick of the React component <Button />. ...
```

from the http://elemental-ui.com/date-picker page.
